### PR TITLE
Follow new mruby API

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -4,6 +4,7 @@ MRuby::Gem::Specification.new('mrbgems-example') do |spec|
 
   spec.objs << ["#{build_dir}/generated.o"]
   spec.test_preload = "#{dir}/test/assert2.rb"
+  spec.add_test_dependency('mruby-print', :core => 'mruby-print')
 
   # rules
   generated_file = "#{build_dir}/generated.c"

--- a/src/example.c
+++ b/src/example.c
@@ -11,7 +11,7 @@ mrb_c_method(mrb_state *mrb, mrb_value self)
 void
 mrb_mrbgems_example_gem_init(mrb_state* mrb) {
   struct RClass *class_example = mrb_define_module(mrb, "ExampleExtension");
-  mrb_define_class_method(mrb, class_example, "c_method", mrb_c_method, ARGS_NONE());
+  mrb_define_class_method(mrb, class_example, "c_method", mrb_c_method, MRB_ARGS_NONE());
 }
 
 void

--- a/test/example.c
+++ b/test/example.c
@@ -13,5 +13,5 @@ void
 mrb_mrbgems_example_gem_test(mrb_state *mrb)
 {
   struct RClass *class_example = mrb_define_module(mrb, "ExampleExtensionTest");
-  mrb_define_class_method(mrb, class_example, "c_method_test", mrb_c_method_test, ARGS_NONE());
+  mrb_define_class_method(mrb, class_example, "c_method_test", mrb_c_method_test, MRB_ARGS_NONE());
 }


### PR DESCRIPTION
Currently, This repository couldn't build on mruby:master.
Because mruby API changed from https://github.com/mruby/mruby/commit/30d580ecbc51852b26ada48eac5e597b1210815b
Or, Need to add `#include "mruby/deprecated.h"`.

I think, It's more better that to update API than to add `#include "mruby/deprecated.h"`.
Because this repository is *example*.

And now, We need to add dependency if we want to use methods defined by mrbgems.(Sorry, I could not find commit)